### PR TITLE
Update license with correct name of the licensor

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Rabobank
+   Copyright 2020 Coöperatieve Rabobank U.A.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Rabobank's legal name is Coöperatieve Rabobank U.A.. I updated the license, so that there will be no confusion regarding the formal licensor.